### PR TITLE
Only enable sentry in production

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,9 +19,6 @@
     </script>
 
     <script src="https://cdn.ravenjs.com/3.5.0/vue/raven.min.js"></script>
-    <script>
-      Raven.config('https://16898ed2dde14c9e800bacf360e9fb01@sentry.io/173107').install();
-    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/src/main.js
+++ b/src/main.js
@@ -52,3 +52,8 @@ new Vue({
   store,
   render: h => h(App)
 })
+
+if (process.env.NODE_ENV === 'production') {
+  Raven.config('https://16898ed2dde14c9e800bacf360e9fb01@sentry.io/173107').install();
+}
+


### PR DESCRIPTION
Removes sentry from the index.html and puts it into a production check in main.js